### PR TITLE
Add Basic Test Suite

### DIFF
--- a/pytest.ini
+++ b/pytest.ini
@@ -1,0 +1,9 @@
+[pytest]
+testpaths = tests
+python_files = test_*.py
+python_classes = Test*
+python_functions = test_*
+asyncio_mode = auto
+filterwarnings =
+    ignore::DeprecationWarning
+    ignore::PendingDeprecationWarning

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,12 @@
+import os
+import pytest
+import sys
+from pathlib import Path
+
+# Add src to python path
+sys.path.insert(0, str(Path(__file__).parent.parent / "src"))
+
+@pytest.fixture(autouse=True)
+def mock_settings_env(monkeypatch):
+    """Ensure tests don't require real API keys or specific environments."""
+    monkeypatch.setenv("OPENAI_API_KEY", "sk-fake-key-for-testing")

--- a/tests/test_audio_processor.py
+++ b/tests/test_audio_processor.py
@@ -1,0 +1,61 @@
+import numpy as np
+import pytest
+from audio.processor import AudioProcessor
+
+def test_audio_processor_init():
+    processor = AudioProcessor(target_sample_rate=16000)
+    assert processor.target_sample_rate == 16000
+
+def test_to_mono():
+    processor = AudioProcessor()
+
+    # Already mono
+    mono_audio = np.array([0.1, 0.2, 0.3])
+    assert np.array_equal(processor.to_mono(mono_audio), mono_audio)
+
+    # Stereo
+    stereo_audio = np.array([[0.1, 0.2, 0.3], [0.5, 0.6, 0.7]])
+    expected_mono = np.array([0.3, 0.4, 0.5])
+    processed_mono = processor.to_mono(stereo_audio)
+    assert np.allclose(processed_mono, expected_mono)
+
+def test_split_channels():
+    processor = AudioProcessor()
+
+    # Stereo [2, samples]
+    stereo_audio = np.array([[0.1, 0.2, 0.3], [0.5, 0.6, 0.7]])
+    left, right = processor.split_channels(stereo_audio)
+    assert np.array_equal(left, stereo_audio[0])
+    assert np.array_equal(right, stereo_audio[1])
+
+    # Stereo [samples, 2]
+    stereo_audio_t = stereo_audio.T
+    left, right = processor.split_channels(stereo_audio_t)
+    assert np.array_equal(left, stereo_audio_t[:, 0])
+    assert np.array_equal(right, stereo_audio_t[:, 1])
+
+def test_normalize():
+    processor = AudioProcessor()
+    audio = np.array([0.5, -1.0, 2.0])
+    normalized = processor.normalize(audio)
+    assert np.max(np.abs(normalized)) == 1.0
+    assert normalized[2] == 1.0
+    assert normalized[1] == -0.5
+
+def test_resample_fallback():
+    # Test linear interpolation fallback when librosa is not used/available
+    # or just verify it works
+    processor = AudioProcessor(target_sample_rate=16000)
+    audio = np.array([0.0, 1.0, 0.0, -1.0])
+    # Resample from 8000 to 16000 (double the length)
+    resampled = processor.resample(audio, original_sr=8000, target_sr=16000)
+    assert len(resampled) == 8
+
+def test_prepare_for_whisper():
+    processor = AudioProcessor(target_sample_rate=16000)
+    stereo_audio = np.array([[0.1, 0.2], [0.3, 0.4]])
+    processed = processor.prepare_for_whisper(stereo_audio, sample_rate=8000)
+
+    assert processed.dtype == np.float32
+    assert processed.ndim == 1
+    assert np.max(np.abs(processed)) <= 1.0

--- a/tests/test_intent_extractor.py
+++ b/tests/test_intent_extractor.py
@@ -1,0 +1,79 @@
+import pytest
+from unittest.mock import AsyncMock, MagicMock, patch
+from analysis.intent_extractor import IntentExtractor
+from analysis.models import ExtractedInfo, IntentCategory, CallerType
+
+@pytest.mark.asyncio
+async def test_intent_extractor_init():
+    extractor = IntentExtractor(api_key="sk-test-key")
+    assert extractor.api_key == "sk-test-key"
+    assert extractor.model_name == "gpt-4o-mini"
+
+@pytest.mark.asyncio
+@patch("analysis.intent_extractor.Agent")
+async def test_extract_async(mock_agent_class):
+    # Mocking the Agent run result
+    mock_agent = mock_agent_class.return_value
+    mock_run_result = MagicMock()
+    mock_run_result.output = ExtractedInfo(
+        caller_name="John Doe",
+        primary_intent=IntentCategory.BILLING
+    )
+    mock_agent.run = AsyncMock(return_value=mock_run_result)
+
+    extractor = IntentExtractor(api_key="sk-test-key")
+    result = await extractor.extract("My name is John Doe and I want to pay my bill.")
+
+    assert result.caller_name == "John Doe"
+    assert result.primary_intent == IntentCategory.BILLING
+    assert mock_agent.run.called
+
+def test_extract_sync():
+    # Since it calls the async version, we can mock extract
+    extractor = IntentExtractor(api_key="sk-test-key")
+    with patch.object(extractor, "extract", new_callable=AsyncMock) as mock_extract:
+        mock_extract.return_value = ExtractedInfo(caller_name="Jane Doe")
+        result = extractor.extract_sync("My name is Jane Doe")
+        assert result.caller_name == "Jane Doe"
+        assert mock_extract.called
+
+def test_get_intent_display():
+    extractor = IntentExtractor(api_key="sk-test-key")
+
+    info = ExtractedInfo(primary_intent=IntentCategory.BILLING)
+    assert extractor.get_intent_display(info) == "Billing Inquiry"
+
+    info = ExtractedInfo(primary_intent=IntentCategory.UNKNOWN)
+    assert extractor.get_intent_display(info) == "Determining intent..."
+
+def test_format_caller_info():
+    extractor = IntentExtractor(api_key="sk-test-key")
+    info = ExtractedInfo(
+        caller_name="John Doe",
+        caller_company="Acme Corp",
+        caller_type=CallerType.BUSINESS,
+        contact_info="john@example.com",
+        account_number="12345"
+    )
+
+    formatted = extractor.format_caller_info(info)
+    assert formatted["Name"] == "John Doe"
+    assert formatted["Company"] == "Acme Corp"
+    assert formatted["Type"] == "Business"
+    assert formatted["Contact"] == "john@example.com"
+    assert formatted["Account #"] == "12345"
+
+def test_should_skip_extraction():
+    extractor = IntentExtractor(api_key="sk-test-key")
+
+    # First call, don't skip
+    assert extractor._should_skip_extraction("Short text") is False
+
+    # Set last transcript
+    extractor._last_transcript = "This is a long enough transcript to start with."
+
+    # Tiny change, skip
+    assert extractor._should_skip_extraction(extractor._last_transcript + " more words") is True
+
+    # Large change, don't skip
+    assert extractor._should_skip_extraction(extractor._last_transcript + " word1 word2 word3 word4 word5 word6 word7 word8 word9 word10 word11") is False

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -1,0 +1,70 @@
+import pytest
+from analysis.models import (
+    RubricResult,
+    RubricItem,
+    AnalysisTriggerState,
+    IntentCategory,
+    CallerType
+)
+
+def test_rubric_result_completion_percentage():
+    result = RubricResult(
+        items=[],
+        score=0.0,
+        completed_count=2,
+        total_count=10
+    )
+    assert result.completion_percentage == 20.0
+
+    result.total_count = 0
+    assert result.completion_percentage == 0.0
+
+def test_analysis_trigger_state_should_analyze():
+    state = AnalysisTriggerState(
+        last_analysis_time=100.0,
+        last_word_count=50
+    )
+
+    # Sentence completion trigger
+    # In src/analysis/models.py:
+    # new_words = current_words - self.last_word_count
+    # if transcript.rstrip().endswith((".", "?", "!")):
+    #     if new_words >= 5:
+
+    # "This is a complete sentence." has 5 words. 5 - 0 = 5. Wait, last_word_count=50.
+    # If transcript is "This is a complete sentence.", current_words is 5.
+    # new_words = 5 - 50 = -45.
+    # So we need a transcript with 55 words to have new_words = 5.
+
+    base_transcript = "word " * 50
+    complete_sentence = "This is a complete sentence." # 5 words
+    transcript = base_transcript + complete_sentence
+
+    assert state.should_analyze(transcript, 101.0) is True
+
+    # Too few new words for sentence completion trigger
+    short_sentence = "Wait." # 1 word
+    assert state.should_analyze(base_transcript + short_sentence, 101.0) is False
+
+    # Time threshold trigger
+    # if time_since_last >= min_interval_sec and new_words >= 5:
+    # min_interval_sec defaults to 10.0
+    assert state.should_analyze(base_transcript + "word " * 5, 111.0) is True
+
+    # Word count trigger
+    # if new_words >= min_new_words:
+    # min_new_words defaults to 15
+    assert state.should_analyze(base_transcript + "word " * 15, 101.0) is True
+
+    # No trigger
+    assert state.should_analyze(base_transcript + "word " * 4, 101.0) is False
+
+def test_analysis_trigger_state_update():
+    state = AnalysisTriggerState(
+        last_analysis_time=100.0,
+        last_word_count=50
+    )
+
+    state.update_after_analysis("word " * 60, 110.0)
+    assert state.last_analysis_time == 110.0
+    assert state.last_word_count == 60

--- a/tests/test_rubric_scorer.py
+++ b/tests/test_rubric_scorer.py
@@ -1,0 +1,62 @@
+import pytest
+from unittest.mock import AsyncMock, MagicMock, patch
+from analysis.rubric_scorer import RubricScorer, RubricEvaluation
+from analysis.models import RubricResult
+
+@pytest.mark.asyncio
+async def test_rubric_scorer_init():
+    scorer = RubricScorer(api_key="sk-test-key")
+    assert scorer.api_key == "sk-test-key"
+    assert len(scorer.rubric_items) > 0
+
+@pytest.mark.asyncio
+@patch("analysis.rubric_scorer.Agent")
+async def test_evaluate_async(mock_agent_class):
+    mock_agent = mock_agent_class.return_value
+    mock_run_result = MagicMock()
+    mock_run_result.output = RubricEvaluation(
+        completed_items=["greeting"],
+        evidence={"greeting": "Hello how can I help?"}
+    )
+    mock_agent.run = AsyncMock(return_value=mock_run_result)
+
+    scorer = RubricScorer(api_key="sk-test-key")
+    result = await scorer.evaluate("Hello how can I help?")
+
+    assert result.completed_count == 1
+    assert result.items[0].id == "greeting"
+    assert result.items[0].completed is True
+    assert result.items[0].evidence == "Hello how can I help?"
+    assert mock_agent.run.called
+
+def test_evaluate_sync():
+    scorer = RubricScorer(api_key="sk-test-key")
+    with patch.object(scorer, "evaluate", new_callable=AsyncMock) as mock_evaluate:
+        mock_evaluate.return_value = RubricResult(
+            items=[],
+            score=100.0,
+            completed_count=1,
+            total_count=1
+        )
+        result = scorer.evaluate_sync("Hello")
+        assert result.score == 100.0
+        assert mock_evaluate.called
+
+def test_reset():
+    scorer = RubricScorer(api_key="sk-test-key")
+    scorer._completed_items.add("greeting")
+    scorer._evidence["greeting"] = "evidence"
+
+    scorer.reset()
+    assert len(scorer._completed_items) == 0
+    assert len(scorer._evidence) == 0
+
+def test_get_items_display():
+    scorer = RubricScorer(api_key="sk-test-key")
+    scorer._completed_items.add("greeting")
+    scorer._evidence["greeting"] = "evidence"
+
+    display = scorer.get_items_display()
+    greeting_item = next(item for item in display if item["id"] == "greeting")
+    assert greeting_item["completed"] is True
+    assert greeting_item["evidence"] == "evidence"

--- a/tests/test_whisper_transcriber.py
+++ b/tests/test_whisper_transcriber.py
@@ -1,0 +1,81 @@
+import numpy as np
+import pytest
+from unittest.mock import MagicMock, patch
+from transcription.whisper_transcriber import WhisperTranscriber, TranscriptionResult
+
+def test_whisper_transcriber_init():
+    transcriber = WhisperTranscriber(model_name="tiny", language="en")
+    assert transcriber.model_name == "tiny"
+    assert transcriber.language == "en"
+
+def test_remove_duplicates():
+    transcriber = WhisperTranscriber()
+    # Mocking the buffer to have some previous text
+    transcriber._transcript_buffer = ["Hello world"]
+
+    # Perfect overlap
+    new_text = "Hello world"
+    assert transcriber.remove_duplicates(new_text) == ""
+
+    # Partial overlap
+    new_text = "world how are you"
+    assert transcriber.remove_duplicates(new_text) == "how are you"
+
+    # No overlap
+    new_text = "nice to meet you"
+    assert transcriber.remove_duplicates(new_text) == "nice to meet you"
+
+@patch("transcription.whisper_transcriber.WhisperTranscriber._load_openai_whisper")
+def test_load_model(mock_load):
+    transcriber = WhisperTranscriber()
+    transcriber.load_model()
+    # By default, it tries backends. Since all will fail except our mock
+    # it depends on how we mock it.
+    assert mock_load.called
+
+@patch("transcription.whisper_transcriber.WhisperTranscriber.transcribe")
+def test_transcribe_stream(mock_transcribe):
+    mock_transcribe.return_value = TranscriptionResult(
+        text="Hello", start_time=0.0, end_time=1.0
+    )
+
+    transcriber = WhisperTranscriber()
+    audio = np.zeros(16000)
+    result = transcriber.transcribe_stream(audio)
+
+    assert result.text == "Hello"
+    assert transcriber.full_transcript == "Hello"
+
+    # Second call
+    mock_transcribe.return_value = TranscriptionResult(
+        text="world", start_time=1.0, end_time=2.0
+    )
+    result = transcriber.transcribe_stream(audio)
+    assert transcriber.full_transcript == "Hello world"
+
+def test_reset_transcript():
+    transcriber = WhisperTranscriber()
+    transcriber._transcript_buffer = ["Hello"]
+    transcriber._full_transcript = "Hello"
+
+    transcriber.reset_transcript()
+    assert transcriber._transcript_buffer == []
+    assert transcriber.full_transcript == ""
+
+def test_transcribe_calls_load_model():
+    transcriber = WhisperTranscriber()
+    # Ensure _model is None to trigger load_model
+    transcriber._model = None
+    transcriber._backend = "whisper"
+
+    with patch.object(transcriber, "load_model") as mock_load:
+        # Mock load_model to set _model so transcribe doesn't fail later
+        def side_effect():
+            transcriber._model = MagicMock()
+            transcriber._model.transcribe.return_value = {"text": "Test"}
+
+        mock_load.side_effect = side_effect
+
+        audio = np.zeros(16000)
+        transcriber.transcribe(audio)
+        assert mock_load.called


### PR DESCRIPTION
This PR adds a comprehensive basic test suite to the AudioInsights project. It covers all core modules including audio processing, transcription, intent extraction, and rubric scoring. 

The test suite is designed to be fast and independent of external services or large models by utilizing extensive mocking of OpenAI API and Whisper backends. 

Key changes:
- `pytest.ini`: Standard pytest configuration.
- `tests/conftest.py`: Sets up dummy environment variables and ensures the `src` directory is in the Python path.
- `tests/test_audio_processor.py`: Tests resampling, normalization, and channel splitting.
- `tests/test_whisper_transcriber.py`: Tests transcription logic, duplicate removal, and model loading triggers.
- `tests/test_intent_extractor.py`: Tests LLM-based intent extraction using mocks.
- `tests/test_rubric_scorer.py`: Tests agent evaluation logic against the rubric.
- `tests/test_models.py`: Tests Pydantic models and analysis triggering logic.

Fixes #9

---
*PR created automatically by Jules for task [14919174773722762779](https://jules.google.com/task/14919174773722762779) started by @eashanchawla*