### PR TITLE
Fix Dependency Issues

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -8,7 +8,7 @@ accelerate==0.34.2
 # On Mac with Apple Silicon, install mlx-whisper separately:
 #   pip install mlx-whisper
 # For other platforms, openai-whisper works:
-openai-whisper==20231117
+openai-whisper
 
 # Voice Activity Detection
 silero-vad==5.1
@@ -25,6 +25,7 @@ openai>=1.51.0
 
 # Frontend
 streamlit==1.38.0
+packaging<25
 
 # Data/Utils
 numpy==2.1.1


### PR DESCRIPTION
This change fixes the dependency issues that were preventing the project from being installed and run correctly.

1.  **Updated `openai-whisper`**: The previous version `20231117` was incompatible with Python 3.12 (due to the removal of `pkg_resources`) and NumPy 2.x. Unpinning it allows `pip` to select a compatible version (e.g., `20240930` or later).
2.  **Added `packaging<25`**: `streamlit 1.38.0` has a strict dependency on `packaging<25`, which was being violated by newer versions. Adding this constraint ensures a successful install.

Verification:
- `pip install -r requirements.txt` now completes without errors.
- `from src.analysis import IntentExtractor, RubricScorer` succeeds.
- `from src.transcription import WhisperTranscriber` succeeds.

Fixes #5

---
*PR created automatically by Jules for task [7473865063167551725](https://jules.google.com/task/7473865063167551725) started by @eashanchawla*